### PR TITLE
Fixed login bug with reload of page 

### DIFF
--- a/src/Components/Transactions/AddTransactionCard.jsx
+++ b/src/Components/Transactions/AddTransactionCard.jsx
@@ -7,7 +7,6 @@ import * as API from '../API';
 class AddTransactionCard extends Component {
   constructor(props) {
     super(props);
-    this.toggle = this.toggle.bind(this);
     this.addTransaction = this.addTransaction.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.state = {
@@ -36,7 +35,7 @@ class AddTransactionCard extends Component {
         this.setState({ accountInfo: res });
         window.location.reload();
       }));
-    this.toggle();
+    this.props.toggle();
   }
 
   async handleChange(e) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -46,6 +46,7 @@ const auth = {
           localStorage.setItem('username', userName);
           localStorage.setItem('userId', res.id);
           login = true;
+          window.location.reload();
         } else {
           // handle failed login
           login = false;


### PR DESCRIPTION
The bug on the login page was cause by the local storage information not being loaded in for the API calls a refresh of the page fixes this bug so window.location.reload was added after login was returned. There may be a better way to fix this in the future. We could use userID variable in each API method by getting userinfo from local storage but that seems inelegant.