### PR TITLE
Add categories

### DIFF
--- a/src/Components/API.js
+++ b/src/Components/API.js
@@ -352,3 +352,76 @@ export const deleteBudget = ((userId, id) => axios(
     throw error;
   })
 );
+
+// Categories
+//
+//
+
+// Get All Categories
+export const getCategories = (payload => axios(
+  `${URL}/users/${userID}/categories`, {
+    method: 'GET',
+    headers,
+    data: payload,
+  },
+)
+  .then(response => response.data)
+  .catch((error) => {
+    throw error;
+  })
+);
+
+// Get Category
+export const getCategory = (payload => axios(
+  `${URL}/users/${userID}/categories/${payload.categoryId}`, {
+    method: 'GET',
+    headers,
+    data: payload,
+  },
+)
+  .then(response => response.data)
+  .catch((error) => {
+    throw error;
+  })
+);
+
+// Add Category
+export const addCategory = (payload => axios(
+  `${URL}/users/${userID}/categories`, {
+    method: 'POST',
+    headers,
+    data: payload,
+  },
+)
+  .then(response => response.data)
+  .catch((error) => {
+    throw error;
+  })
+);
+
+// Update Category
+export const updateCategory = (payload => axios(
+  `${URL}/users/${userID}/categories/${payload.categoryId}`, {
+    method: 'PUT',
+    headers,
+    data: payload,
+  },
+)
+  .then(response => response.data)
+  .catch((error) => {
+    throw error;
+  })
+);
+
+// Delete Category
+export const deleteCategory = (payload => axios(
+  `${URL}/users/${userID}/categories/${payload.categoryId}`, {
+    method: 'DELETE',
+    headers,
+  },
+)
+  .then(response => response.data)
+  .catch((error) => {
+    throw error;
+  })
+);

--- a/src/Components/BudgetsCard/Budget.jsx
+++ b/src/Components/BudgetsCard/Budget.jsx
@@ -6,6 +6,32 @@ import PropTypes from 'prop-types';
 import * as API from '../API';
 
 class Budget extends Component {
+  constructor(props) {
+    super(props);
+    this.determineColor = this.determineColor.bind(this);
+    this.state = {
+      spentAmount: 0,
+    };
+  }
+
+  componentDidMount() {
+    const { category } = this.props;
+    let amount = 0;
+
+    API.getTransactions()
+      .then((res) => {
+        for (let i = 0; i < res.length; i += 1) {
+          if (res[i].category === category) {
+            // Multiplies by 100 to remove addition errors with floats
+            amount += parseFloat(res[i].amount * 100);
+          }
+        }
+        this.setState({
+          spentAmount: (amount / 100),
+        });
+      });
+  }
+
   async deleteBudget(e) {
     e.preventDefault();
 
@@ -24,8 +50,11 @@ class Budget extends Component {
   determineColor() {
     const {
       maxAmount,
-      spentAmount,
     } = this.props;
+
+    const {
+      spentAmount,
+    } = this.state;
 
     let color = 'success';
     const percentSpent = (spentAmount / maxAmount);
@@ -44,8 +73,11 @@ class Budget extends Component {
       category,
       deleteButtons,
       maxAmount,
-      spentAmount,
     } = this.props;
+
+    const {
+      spentAmount,
+    } = this.state;
 
     return (
       <React.Fragment>
@@ -120,7 +152,6 @@ Budget.propTypes = {
   deleteButtons: PropTypes.bool.isRequired,
   getBudgets: PropTypes.func.isRequired,
   id: PropTypes.number,
-  spentAmount: PropTypes.number.isRequired,
   maxAmount: PropTypes.number.isRequired,
 };
 

--- a/src/Components/BudgetsCard/_BudgetsCard.jsx
+++ b/src/Components/BudgetsCard/_BudgetsCard.jsx
@@ -85,7 +85,6 @@ class BudgetsCard extends Component {
                     deleteButtons={deleteButtons}
                     getBudgets={this.getBudgets}
                     maxAmount={0}
-                    spentAmount={0}
                   />
                 )
                 : (
@@ -98,7 +97,6 @@ class BudgetsCard extends Component {
                     budgetId,
                     category,
                     maxAmount,
-                    spentAmount,
                   } = budget;
                   return (
                     <Budget
@@ -108,7 +106,6 @@ class BudgetsCard extends Component {
                       id={budgetId}
                       key={budgetId}
                       maxAmount={maxAmount}
-                      spentAmount={spentAmount}
                     />
                   );
                 })
@@ -118,7 +115,6 @@ class BudgetsCard extends Component {
                   deleteButtons={deleteButtons}
                   getBudgets={this.getBudgets}
                   maxAmount={0}
-                  spentAmount={0}
                 />
               )}
             </React.Fragment>


### PR DESCRIPTION
This update resolves the budget spentAmount problem, solely on the frontend.  Originally, we planned to use the Categories entity to assist in calculating a budget's spentAmount.  However, it's not really necessary.  I was able to simply utilize the props of both the budgets, and transactions, to handle this.

We can still implement the categories entity in the future, but it turned out to be a bigger task than I expected.  This update serves as a solution to the problem that we can build off of in future updates.

Resolves #34.