### PR TITLE
Set maxLength for all input fields

### DIFF
--- a/src/Components/AccountsCard/AccountModal.jsx
+++ b/src/Components/AccountsCard/AccountModal.jsx
@@ -50,6 +50,7 @@ class AccountModal extends Component {
                   type="text"
                   name="accountName"
                   id="newAccountName"
+                  maxLength={30}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -60,6 +61,7 @@ class AccountModal extends Component {
                   type="text"
                   name="bankName"
                   id="newBankName"
+                  maxLength={30}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -72,6 +74,7 @@ class AccountModal extends Component {
                   type="select"
                   name="accountType"
                   id="newAccountType"
+                  maxLength={30}
                   readOnly
                   required
                   onChange={e => this.handleChange(e)}
@@ -89,6 +92,7 @@ class AccountModal extends Component {
                     type=""
                     name="balance"
                     id="newBalance"
+                    maxLength={10}
                     required
                     onChange={e => this.handleChange(e)}
                   />

--- a/src/Components/BudgetsCard/BudgetModal.jsx
+++ b/src/Components/BudgetsCard/BudgetModal.jsx
@@ -51,6 +51,7 @@ class BudgetModal extends Component {
                       type="text"
                       name="category"
                       id="newCategory"
+                      maxLength={40}
                       required
                       onChange={e => this.handleChange(e)}
                     />
@@ -71,6 +72,7 @@ class BudgetModal extends Component {
                         placeholder="0"
                         id="newMaxAmount"
                         step="1"
+                        maxLength={10}
                         required
                         onChange={e => this.handleChange(e)}
                       />

--- a/src/Components/EntryCards/_LoginCard.jsx
+++ b/src/Components/EntryCards/_LoginCard.jsx
@@ -54,6 +54,7 @@ class LoginCard extends Component {
                   name="username"
                   id="userName"
                   autoComplete="username"
+                  maxLength={20}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -72,6 +73,7 @@ class LoginCard extends Component {
                   name="password"
                   id="examplePassword"
                   autoComplete="current-password"
+                  maxLength={255}
                   required
                   onChange={e => this.handleChange(e)}
                 />

--- a/src/Components/EntryCards/_SignUpCard.jsx
+++ b/src/Components/EntryCards/_SignUpCard.jsx
@@ -54,6 +54,7 @@ class LoginCard extends Component {
                   type="text"
                   name="firstName"
                   id="firstName"
+                  maxLength={20}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -66,6 +67,7 @@ class LoginCard extends Component {
                   type="text"
                   name="lastName"
                   id="lastName"
+                  maxLength={20}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -79,6 +81,7 @@ class LoginCard extends Component {
                   type="text"
                   name="email"
                   id="email"
+                  maxLength={30}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -97,6 +100,7 @@ class LoginCard extends Component {
                   name="username"
                   id="userName"
                   autoComplete="username"
+                  maxLength={20}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -115,6 +119,7 @@ class LoginCard extends Component {
                   name="password"
                   id="Password"
                   autoComplete="new-password"
+                  maxLength={255}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -138,6 +143,7 @@ class LoginCard extends Component {
                   name="confirmPassword"
                   id="confirmPassword"
                   autoComplete="new-password"
+                  maxLength={255}
                   required
                   onChange={e => this.handleChange(e)}
                 />

--- a/src/Components/Transactions/AddTransactionCard.jsx
+++ b/src/Components/Transactions/AddTransactionCard.jsx
@@ -131,6 +131,7 @@ class AddTransactionCard extends Component {
                 type="select"
                 name="account"
                 id="accountID"
+                maxLength={20}
               >
                 {accounts}
               </Input>
@@ -149,6 +150,7 @@ class AddTransactionCard extends Component {
                   type="text"
                   name="name"
                   id="name"
+                  maxLength={40}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -161,6 +163,7 @@ class AddTransactionCard extends Component {
                   type="text"
                   name="category"
                   id="category"
+                  maxLength={40}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -189,6 +192,7 @@ class AddTransactionCard extends Component {
                       type="text"
                       name="amount"
                       id="amount"
+                      maxLength={10}
                       required
                       onChange={e => this.handleChange(e)}
                     />
@@ -202,6 +206,7 @@ class AddTransactionCard extends Component {
                 type="select"
                 name="account"
                 id="accountID"
+                maxLength={20}
               >
                 {accounts}
               </Input>

--- a/src/Components/Transactions/UpdateTransactionCard.jsx
+++ b/src/Components/Transactions/UpdateTransactionCard.jsx
@@ -51,6 +51,7 @@ class UpdateTransactionCard extends Component {
                   type="text"
                   name="name"
                   id="name"
+                  maxLength={40}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -64,6 +65,7 @@ class UpdateTransactionCard extends Component {
                   type="text"
                   name="category"
                   id="category"
+                  maxLength={40}
                   required
                   onChange={e => this.handleChange(e)}
                 />
@@ -94,6 +96,7 @@ class UpdateTransactionCard extends Component {
                       type="text"
                       name="amount"
                       id="amount"
+                      maxLength={10}
                       required
                       onChange={e => this.handleChange(e)}
                     />

--- a/src/Views/_User.jsx
+++ b/src/Views/_User.jsx
@@ -134,6 +134,7 @@ class User extends Component {
                       type="text"
                       name="userInfo.firstName"
                       id="firstName"
+                      maxLength={20}
                       onChange={e => this.handleChange(e)}
                     />
                   </InputGroup>
@@ -146,6 +147,7 @@ class User extends Component {
                       type="text"
                       name="lastName"
                       id="lastName"
+                      maxLength={20}
                       onChange={e => this.handleChange(e)}
                     />
                   </InputGroup>
@@ -158,6 +160,7 @@ class User extends Component {
                       type="text"
                       name="email"
                       id="email"
+                      maxLength={30}
                       onChange={e => this.handleChange(e)}
                     />
                   </InputGroup>


### PR DESCRIPTION
This pr adds the maxLength parameter to all inputs fields.  This is set to restrict inputs to adhere to the maximum lengths set by the [backend](https://github.com/Russelldan554/budget_backend).